### PR TITLE
Fix Preset Event Factories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,12 @@ java {
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = "sources"
+	archiveClassifier = "sources"
 	from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-	classifier = "javadoc"
+	archiveClassifier = "javadoc"
 	from javadoc.destinationDir
 }
 

--- a/src/main/java/blue/endless/tinyevents/ChainEventFactories.java
+++ b/src/main/java/blue/endless/tinyevents/ChainEventFactories.java
@@ -30,142 +30,123 @@ import java.util.function.IntUnaryOperator;
 import java.util.function.LongUnaryOperator;
 import java.util.function.UnaryOperator;
 
-import blue.endless.tinyevents.Event.Entry;
 import blue.endless.tinyevents.function.BooleanUnaryOperator;
 
 /**
  * Contains EventFactories and static factory methods for making Events which have the same inputs and outputs, and
  * whose handlers "progressively modify" a value to create a result. There is no priority system for these events, and
  * no handler can count on having the final say in the result.
- * 
+ *
  * <p><b>Example:</b><br>
  * A jump-strength-event. Let's say the event is an {@code Event<IntUnaryOperator>}, and that there are
  * two handlers registered:
- * 
+ *
  * <ul>
  *   <p>{@code (x) -> x + 1}
  *   <p>{@code (x) -> x / 2}
  * </ul>
- * 
+ * <p>
  * The first handler receives the value 5, and adds one, yielding 6. The second one receives 6,
  * and halves the value, yielding 3. The event's invoker returns with the value 3. Each handler receives the value "so
  * far", and modifies it.
  */
 public class ChainEventFactories {
-	public static final EventFactory<IntUnaryOperator>      MODIFY_INT    = ChainEventFactories::intUnaryOperator;
-	public static final EventFactory<LongUnaryOperator>     MODIFY_LONG   = ChainEventFactories::longUnaryOperator;
-	public static final EventFactory<DoubleUnaryOperator>   MODIFY_DOUBLE = ChainEventFactories::doubleUnaryOperator;
-	public static final EventFactory<BooleanUnaryOperator>  MODIFY_BOOLEAN= ChainEventFactories::booleanUnaryOperator;
-	public static final EventFactory<UnaryOperator<String>> MODIFY_STRING = () -> unaryOperator();
+	public static final EventFactory<IntUnaryOperator>      MODIFY_INT     = ChainEventFactories::intUnaryOperator;
+	public static final EventFactory<LongUnaryOperator>     MODIFY_LONG    = ChainEventFactories::longUnaryOperator;
+	public static final EventFactory<DoubleUnaryOperator>   MODIFY_DOUBLE  = ChainEventFactories::doubleUnaryOperator;
+	public static final EventFactory<BooleanUnaryOperator>  MODIFY_BOOLEAN = ChainEventFactories::booleanUnaryOperator;
+	public static final EventFactory<UnaryOperator<String>> MODIFY_STRING  = ChainEventFactories::unaryOperator;
 	
 	/**
 	 * Creates an Event which takes in a single value and modifies it.
+	 *
 	 * @param <T> The type of data that will be modified
 	 * @return the new Event
 	 */
 	public static <T> Event<UnaryOperator<T>> unaryOperator() {
-		return new Event<UnaryOperator<T>>(
-			(handlers) -> (T t) -> {
-				T result = t;
-				
-				for(Entry<UnaryOperator<T>> entry : handlers) {
-					result = entry.handler().apply(result);
-				}
-				
-				return result;
-			}
-		);
+		return new Event<>(handlers -> t -> {
+			T result = t;
+			
+			for (var entry : handlers) result = entry.handler().apply(result);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an Event which takes in an int value and modifies it.
+	 *
 	 * @return the new Event
 	 */
 	public static Event<IntUnaryOperator> intUnaryOperator() {
-		return new Event<IntUnaryOperator>(
-			(handlers) -> (int value) -> {
-				int result = value;
-				
-				for(Entry<IntUnaryOperator> entry : handlers) {
-					result = entry.handler().applyAsInt(result);
-				}
-				
-				return result;
-			}
-		);
+		return new Event<>(handlers -> value -> {
+			int result = value;
+			
+			for (var entry : handlers) result = entry.handler().applyAsInt(result);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an Event which takes in a long value and modifies it.
+	 *
 	 * @return the new Event
 	 */
 	public static Event<LongUnaryOperator> longUnaryOperator() {
-		return new Event<LongUnaryOperator>(
-			(handlers) -> (long value) -> {
-				long result = value;
-				
-				for(Entry<LongUnaryOperator> entry : handlers) {
-					result = entry.handler().applyAsLong(result);
-				}
-				
-				return result;
-			}
-		);
+		return new Event<>(handlers -> value -> {
+			long result = value;
+			
+			for (var entry : handlers) result = entry.handler().applyAsLong(result);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an Event which takes in a double value and modifies it.
+	 *
 	 * @return the new Event
 	 */
 	public static Event<DoubleUnaryOperator> doubleUnaryOperator() {
-		return new Event<DoubleUnaryOperator>(
-			(handlers) -> (double value) -> {
-				double result = value;
-				
-				for(Entry<DoubleUnaryOperator> entry : handlers) {
-					result = entry.handler().applyAsDouble(result);
-				}
-				
-				return result;
-			}
-		);
+		return new Event<>(handlers -> value -> {
+			double result = value;
+			
+			for (var entry : handlers) result = entry.handler().applyAsDouble(result);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an Event which takes in a boolean value and modifies it.
+	 *
 	 * @return the new Event
 	 */
 	public static Event<BooleanUnaryOperator> booleanUnaryOperator() {
-		return new Event<BooleanUnaryOperator>(
-			(handlers) -> (boolean value) -> {
-				boolean result = value;
-				
-				for(Entry<BooleanUnaryOperator> entry : handlers) {
-					result = entry.handler().applyAsBoolean(result);
-				}
-				
-				return result;
-			}
-		);
+		return new Event<>(handlers -> value -> {
+			boolean result = value;
+			
+			for (var entry : handlers) result = entry.handler().applyAsBoolean(result);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an Event which takes in two values and modifies the first one.
+	 *
 	 * @param <T> The type of data that will be modified
 	 * @param <U> The type of the second function argument that will NOT be replaced/modified
 	 * @return The fully-modified value.
 	 */
 	public static <T, U> Event<BiFunction<T, U, T>> biFunction() {
-		return new Event<BiFunction<T, U, T>>(
-			(handlers) -> (T t, U u) -> {
-				T result = t;
-				
-				for(Entry<BiFunction<T, U, T>> entry : handlers) {
-					result = entry.handler().apply(result, u);
-				}
-				
-				return result;
-			}
-		);
+		return new Event<>(handlers -> (t, u) -> {
+			T result = t;
+			
+			for (var entry : handlers) result = entry.handler().apply(result, u);
+			
+			return result;
+		});
 	}
 }

--- a/src/main/java/blue/endless/tinyevents/EventFactories.java
+++ b/src/main/java/blue/endless/tinyevents/EventFactories.java
@@ -44,61 +44,48 @@ import java.util.function.IntPredicate;
 import java.util.function.LongBinaryOperator;
 import java.util.function.Supplier;
 
-import blue.endless.tinyevents.Event.Entry;
 import blue.endless.tinyevents.function.BooleanBinaryOperator;
 import blue.endless.tinyevents.function.IntBiConsumer;
 
 public class EventFactories {
-	
 	public static EventFactory<BooleanSupplier> BOOLEAN_SUPPLIER_FAVOR_FALSE = () -> EventFactories.booleanSupplier(BooleanBinaryOperator.AND);
 	public static EventFactory<BooleanSupplier> BOOLEAN_SUPPLIER_FAVOR_TRUE  = () -> EventFactories.booleanSupplier(BooleanBinaryOperator.OR);
-	public static EventFactory<DoubleConsumer> DOUBLE_CONSUMER = EventFactories::doubleConsumer;
+	public static EventFactory<DoubleConsumer>  DOUBLE_CONSUMER              = EventFactories::doubleConsumer;
 	public static EventFactory<DoublePredicate> DOUBLE_PREDICATE_FAVOR_FALSE = () -> EventFactories.doublePredicate(BooleanBinaryOperator.AND);
 	public static EventFactory<DoublePredicate> DOUBLE_PREDICATE_FAVOR_TRUE  = () -> EventFactories.doublePredicate(BooleanBinaryOperator.OR);
-	public static EventFactory<IntConsumer> INT_CONSUMER = EventFactories::intConsumer;
-	
-	
-	
-	
-	public static EventFactory<Runnable> RUNNABLE = EventFactories::runnable;
+	public static EventFactory<IntConsumer>     INT_CONSUMER                 = EventFactories::intConsumer;
+	public static EventFactory<Runnable>        RUNNABLE                     = EventFactories::runnable;
 	
 	/**
 	 * Creates an event that BiConsumer event-handlers may be registered to.
+	 *
 	 * @param <X> The type of the first parameter that event-handlers will receive
 	 * @param <Y> The type of the second parameter that event-handlers will receive
 	 * @return the new Event
 	 */
 	public static <X, Y> Event<BiConsumer<X, Y>> biConsumer() {
-		return new Event<BiConsumer<X, Y>>(
-			(handlers) -> (X x, Y y) -> {
-				for(Entry<BiConsumer<X, Y>> entry : handlers) {
-					entry.handler().accept(x, y);
-				}
-			}
+		return new Event<>(handlers -> (x, y) ->
+				handlers.forEach(entry -> entry.handler().accept(x, y))
 		);
 	}
 	
 	/**
 	 * Creates an event that Functions may respond to. All the responders are turned into a single value by recursively
 	 * applying the reducer function for every two values returned.
-	 * @param <T> The type of the first argument that event-handlers will receive
-	 * @param <U> The type of the second argument that event-handlers will receive
-	 * @param <V> The type of data that event-handlers will provide
+	 *
+	 * @param <T>     The type of the first argument that event-handlers will receive
+	 * @param <U>     The type of the second argument that event-handlers will receive
+	 * @param <V>     The type of data that event-handlers will provide
 	 * @param reducer a function which will turn responses into a single value
 	 * @return the new Event
 	 */
 	public static <T, U, V> Event<BiFunction<T, U, V>> biFunction(BinaryOperator<V> reducer) {
-		return new Event<BiFunction<T, U, V>>((handlers) -> (T t, U u) -> {
-			boolean firstLoop = true;
+		return new Event<>(handlers -> (t, u) -> {
 			V result = null;
-			for(Entry<BiFunction<T, U, V>> entry : handlers) {
-				V cur = entry.handler().apply(t, u);
-				if (firstLoop) {
-					result = cur;
-					firstLoop = false;
-				} else {
-					reducer.apply(result, cur);
-				}
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().apply(t, u);
+				result = i == 0 ? cur : reducer.apply(result, cur);
 			}
 			
 			return result;
@@ -107,187 +94,139 @@ public class EventFactories {
 	
 	/**
 	 * Creates an Event that handlers can use to vote on a single boolean-valued result.
+	 *
 	 * @param reducer A function that reconciles multiple votes to produce a single value
 	 * @return the new Event
 	 */
 	public static Event<BooleanSupplier> booleanSupplier(BooleanBinaryOperator reducer) {
-		return new Event<BooleanSupplier>(
-			(handlers) -> () -> {
-				boolean first = true;
-				boolean result = false;
-				for(Entry<BooleanSupplier> entry : handlers) {
-					if (first) {
-						result = entry.handler().getAsBoolean();
-						first = false;
-					} else {
-						result = reducer.apply(result, entry.handler().getAsBoolean());
-					}
-				}
-				return result;
+		return new Event<>(handlers -> () -> {
+			boolean result = false;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().getAsBoolean();
+				result = i == 0 ? cur : reducer.apply(result, cur);
 			}
-		);
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an event that Consumer event-handlers may be registered to.
+	 *
 	 * @param <X> The type of data which event-handlers will receive (consume)
 	 * @return the new Event
 	 */
 	public static <X> Event<Consumer<X>> consumer() {
-		return new Event<Consumer<X>>(
-			(handlers) -> (X eventPayload) -> {
-				for(Entry<Consumer<X>> entry : handlers) {
-					entry.handler().accept(eventPayload);
-				}
-			}
+		return new Event<>(handlers -> eventPayload ->
+				handlers.forEach(entry -> entry.handler().accept(eventPayload))
 		);
 	}
 	
 	/**
 	 * Creates an event that DoubleConsumer event-handlers may be registered to.
+	 *
 	 * @return the new Event
 	 */
 	public static Event<DoubleConsumer> doubleConsumer() {
-		return new Event<DoubleConsumer>(
-			(handlers) -> (double value) -> {
-				for(Entry<DoubleConsumer> entry : handlers) {
-					entry.handler().accept(value);
-				}
-			}
+		return new Event<>(handlers -> value ->
+				handlers.forEach(entry -> entry.handler().accept(value))
 		);
 	}
 	
 	/**
 	 * Creates an event that receives a double value and produces a reference-typed result.
-	 * @param <X> The "result type" for the Event to create
+	 *
+	 * @param <X>     The "result type" for the Event to create
 	 * @param reducer A function that turns multiple handler-results into a single event-result
 	 * @return the new Event
 	 */
 	public static <X> Event<DoubleFunction<X>> doubleFunction(BinaryOperator<X> reducer) {
-		return new Event<DoubleFunction<X>>(
-			(handlers) -> (double value) -> {
-				boolean firstLoop = true;
-				X result = null;
-				for(Entry<DoubleFunction<X>> entry : handlers) {
-					X cur = entry.handler().apply(value);
-					if (firstLoop) {
-						result = cur;
-						firstLoop = false;
-					} else {
-						reducer.apply(result, cur);
-					}
-				}
-				
-				return result;
+		return new Event<>(handlers -> value -> {
+			X result = null;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().apply(value);
+				result = i == 0 ? cur : reducer.apply(result, cur);
 			}
-		);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an event that receives a double value and produces a boolean result.
+	 *
 	 * @param reducer A function that turns multiple handler-results into a single event-result
 	 * @return the new Event
 	 */
 	public static Event<DoublePredicate> doublePredicate(BooleanBinaryOperator reducer) {
-		return new Event<DoublePredicate>(
-			(handlers) -> (double value) -> {
-				boolean firstLoop = true;
-				boolean result = false;
-				for(Entry<DoublePredicate> entry : handlers) {
-					boolean cur = entry.handler().test(value);
-					if (firstLoop) {
-						result = cur;
-						firstLoop = false;
-					} else {
-						reducer.apply(result, cur);
-					}
-				}
-				
-				return result;
+		return new Event<>(handlers -> value -> {
+			boolean result = false;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final boolean cur = entry.handler().test(value);
+				result = i == 0 ? cur : reducer.apply(result, cur);
 			}
-		);
+			
+			return result;
+		});
 	}
 	
 	public static Event<DoubleSupplier> doubleSupplier(DoubleBinaryOperator reducer) {
-		return new Event<DoubleSupplier>(
-			(handlers) -> () -> {
-				boolean firstLoop = true;
-				double result = 0D;
-				for(Entry<DoubleSupplier> entry : handlers) {
-					double cur = entry.handler().getAsDouble();
-					if (firstLoop) {
-						result = cur;
-						firstLoop = false;
-					} else {
-						reducer.applyAsDouble(cur, result);
-					}
-				}
-				
-				return result;
+		return new Event<>(handlers -> () -> {
+			double result = 0;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().getAsDouble();
+				result = i == 0 ? cur : reducer.applyAsDouble(cur, result);
 			}
-		);
+			
+			return result;
+		});
 	}
 	
 	public static Event<DoubleToIntFunction> doubleToIntFunction(IntBinaryOperator reducer) {
-		return new Event<DoubleToIntFunction>(
-			(handlers) -> (value) -> {
-				boolean firstLoop = true;
-				int result = 0;
-				for(Entry<DoubleToIntFunction> entry : handlers) {
-					int cur = entry.handler().applyAsInt(value);
-					if (firstLoop) {
-						result = cur;
-						firstLoop = false;
-					} else {
-						reducer.applyAsInt(cur, result);
-					}
-				}
-				
-				return result;
+		return new Event<>(handlers -> value -> {
+			int result = 0;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().applyAsInt(value);
+				result = i == 0 ? cur : reducer.applyAsInt(cur, result);
 			}
-		);
+			
+			return result;
+		});
 	}
 	
 	public static Event<DoubleToLongFunction> doubleToLongFunction(LongBinaryOperator reducer) {
-		return new Event<DoubleToLongFunction>(
-			(handlers) -> (value) -> {
-				boolean firstLoop = true;
-				long result = 0;
-				for(Entry<DoubleToLongFunction> entry : handlers) {
-					long cur = entry.handler().applyAsLong(value);
-					if (firstLoop) {
-						result = cur;
-						firstLoop = false;
-					} else {
-						reducer.applyAsLong(cur, result);
-					}
-				}
-				
-				return result;
+		return new Event<>(handlers -> value -> {
+			long result = 0;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().applyAsLong(value);
+				result = i == 0 ? cur : reducer.applyAsLong(cur, result);
 			}
-		);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an event that Functions may respond to. All the responders are turned into a single value by recursively
 	 * applying the reducer function for every two values returned.
-	 * @param <T> The type of data that event-handlers will receive
-	 * @param <U> The type of data that event-handlers will provide
+	 *
+	 * @param <T>     The type of data that event-handlers will receive
+	 * @param <U>     The type of data that event-handlers will provide
 	 * @param reducer a function which will turn responses into a single value
 	 * @return the new Event
 	 */
 	public static <T, U> Event<Function<T, U>> function(BinaryOperator<U> reducer) {
-		return new Event<Function<T, U>>((handlers) -> (T t) -> {
-			boolean firstLoop = true;
+		return new Event<>(handlers -> t -> {
 			U result = null;
-			for(Entry<Function<T, U>> entry : handlers) {
-				U cur = entry.handler().apply(t);
-				if (firstLoop) {
-					result = cur;
-					firstLoop = false;
-				} else {
-					reducer.apply(result, cur);
-				}
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().apply(t);
+				result = i == 0 ? cur : reducer.apply(result, cur);
 			}
 			
 			return result;
@@ -295,141 +234,98 @@ public class EventFactories {
 	}
 	
 	public static Event<IntConsumer> intConsumer() {
-		return new Event<IntConsumer>(
-				(handlers) -> (int value) -> {
-					for(Entry<IntConsumer> entry : handlers) {
-						entry.handler().accept(value);
-					}
-				}
+		return new Event<>(handlers -> value ->
+				handlers.forEach(entry -> entry.handler().accept(value))
 		);
 	}
 	
 	/**
 	 * Creates an event that receives an integer value and produces a reference-typed result.
-	 * @param <X> The "result type" for the Event to create
+	 *
+	 * @param <X>     The "result type" for the Event to create
 	 * @param reducer A function that turns multiple handler-results into a single event-result
 	 * @return the new Event
 	 */
 	public static <X> Event<IntFunction<X>> intFunction(BinaryOperator<X> reducer) {
-		return new Event<IntFunction<X>>(
-			(handlers) -> (int value) -> {
-				boolean firstLoop = true;
-				X result = null;
-				for(Entry<IntFunction<X>> entry : handlers) {
-					X cur = entry.handler().apply(value);
-					if (firstLoop) {
-						result = cur;
-						firstLoop = false;
-					} else {
-						reducer.apply(result, cur);
-					}
-				}
-				
-				return result;
+		return new Event<>(handlers -> value -> {
+			X result = null;
+			
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().apply(value);
+				result = i == 0 ? cur : reducer.apply(result, cur);
 			}
-		);
+			
+			return result;
+		});
 	}
 	
 	/**
 	 * Creates an event that receives an integer value and produces a boolean result.
+	 *
 	 * @param reducer A function that turns multiple handler-results into a single event-result
 	 * @return the new Event
 	 */
 	public static Event<IntPredicate> intPredicate(BooleanBinaryOperator reducer) {
-		return new Event<IntPredicate>(
-			(handlers) -> (int value) -> {
-				boolean firstLoop = true;
-				boolean result = false;
-				for(Entry<IntPredicate> entry : handlers) {
-					boolean cur = entry.handler().test(value);
-					if (firstLoop) {
-						result = cur;
-						firstLoop = false;
-					} else {
-						reducer.apply(result, cur);
-					}
-				}
-				
-				return result;
+		return new Event<>(handlers -> value -> {
+			boolean result = false;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().test(value);
+				result = i == 0 ? cur : reducer.apply(result, cur);
 			}
-		);
+			
+			return result;
+		});
 	}
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
-	
 	
 	
 	/**
 	 * Creates an event that Runnable event-handlers may be registered to.
+	 *
 	 * @return the new Event
 	 */
 	public static Event<Runnable> runnable() {
-		return new Event<Runnable>(
-			(handlers) -> () -> {
-				for(Entry<Runnable> entry : handlers) {
-					entry.handler().run();
-				}
-			}
+		return new Event<>(handlers -> () ->
+				handlers.forEach(entry -> entry.handler().run())
 		);
 	}
 	
 	/**
 	 * Creates an event that Suppliers may respond to. Responders which are registered later will override
 	 * earlier ones.
+	 *
 	 * @param <X> The type of data that event-handlers will provide
 	 * @return the new Event
 	 */
 	public static <X> Event<Supplier<X>> supplier() {
-		return supplier((a,b) -> b);
+		return supplier((a, b) -> b);
 	}
 	
 	/**
 	 * Creates an event that Suppliers may respond to. All the responders are coalesced with the reducer function. For
 	 * instance, if responders reply with `[ 1, 2, 3, 4 ]` with reducer function `(a, b) -&gt; a + b`, the operations
 	 * performed will be `((1 + 2) + 3) + 4`.
-	 * @param <X> The type of data that event-handlers will provide
+	 *
+	 * @param <X>     The type of data that event-handlers will provide
 	 * @param reducer a function which will be used to coalesce responses into a single value
 	 * @return the new Event
 	 */
 	public static <X> Event<Supplier<X>> supplier(BinaryOperator<X> reducer) {
-		return new Event<Supplier<X>>(
-				(handlers) -> () -> {
-					X result = null;
-					for(Entry<Supplier<X>> entry : handlers) {
-						if (result == null) {
-							result = entry.handler().get();
-						} else {
-							result = reducer.apply(result, entry.handler().get());
-						}
-					}
-					
-					return result;
-				}
-			);
+		return new Event<>(handlers -> () -> {
+			X result = null;
+			for (int i = 0, size = handlers.size(); i < size; i++) {
+				final var entry = handlers.get(i);
+				final var cur = entry.handler().get();
+				result = i == 0 ? cur : reducer.apply(result, cur);
+			}
+			return result;
+		});
 	}
 	
 	public static Event<IntBiConsumer> intBiConsumer() {
-		return new Event<IntBiConsumer>(
-				(handlers) -> (int x, int y) -> {
-					for(Entry<IntBiConsumer> entry : handlers) {
-						entry.handler().accept(x, y);
-					}
-				}
-			);
+		return new Event<>(handlers -> (x, y) ->
+				handlers.forEach(entry -> entry.handler().accept(x, y))
+		);
 	}
 }


### PR DESCRIPTION
- Applies reducers properly and uses indexed for loops instead of redundant `firstLoop` vars.
- Removes redundant type arguments and collapses loops into chains.
- Fixes buildscript reference to `archiveClassifier`.

This really makes the repetitive nature of the code apparent, and while I can't find an immediate solution, the IDE is now also very aware of it, warning of repeated code over 10 lines long.